### PR TITLE
Fix new Python 3.8 warnings

### DIFF
--- a/campdown/helpers.py
+++ b/campdown/helpers.py
@@ -19,7 +19,7 @@ def strike(string):
         string (str): string to apply strikethrough to.
     """
 
-    if platform.system() is not "Windows":
+    if platform.system() != "Windows":
         return '\u0336'.join(string) + '\u0336'
 
     else:
@@ -76,7 +76,7 @@ def safe_filename(string):
 
     string = string.replace('/', '&').replace('\\', '')
 
-    if platform.system() is "Windows":
+    if platform.system() == "Windows":
         string = re.sub('[":*?<>|]', "", string)
 
     return string


### PR DESCRIPTION
This fixes the new warnings emitted under Python 3.8.
```
/usr/lib/python3.8/site-packages/campdown/helpers.py:22: SyntaxWarning: "is not" with a literal. Did you mean "!="?
/usr/lib/python3.8/site-packages/campdown/helpers.py:79: SyntaxWarning: "is" with a literal. Did you mean "=="?    
```