### PR TITLE
Fix issue Cannot download any longer #6

### DIFF
--- a/campdown/track.py
+++ b/campdown/track.py
@@ -174,6 +174,9 @@ class Track:
             self.content, "data-tralbum=\"{", "}\"")).replace("'", "\"")
         )
 
+        # Escape additional " for all values. Check issue #6 and corresponding commit
+        raw_info = re.sub(r'((?<![\\,:{])"(?![:,}]))', r'\\"', raw_info)
+        
         info = json.loads(raw_info)
 
         if "trackinfo" in info:


### PR DESCRIPTION
Fixes json.decoder.JSONDecodeError if additional " are present in the json values of the raw_info string, #6

A json.decoder.JSONDecodeError was thrown if raw_info contained a substring like "key":"val"ue". The additional " caused the json parser to fail.

This commit fixes the issue with a regex that escapes all " that are NOT prefixed by either of \,:{ and are NOT suffixed by either one of ,:}. The character ,:{} are added to not escape " that are part of valid json like {"key":"value"} additionally \ was added to also exclude already escaped " like {"key":"val\"ue"}.

Remarks:
This is a quick fix and should be replaced by a proper sanitize function