### PR TITLE
Fix #6 File buffer not flushed

### DIFF
--- a/campdown/helpers.py
+++ b/campdown/helpers.py
@@ -387,6 +387,7 @@ def download_file(url, output, name, force=False, verbose=False, silent=False, s
 
                         # Flush the output buffer so we can overwrite the same line.
                         sys.stdout.flush()
+                f.flush()
 
                 # Verify our download size for completion. Since the file sizes will
                 # not entirely match up because of possible ID3 tag differences or

--- a/campdown/helpers.py
+++ b/campdown/helpers.py
@@ -251,9 +251,9 @@ def calculate_confidence(inspected, expected, percentage):
 
     # Debug lines to help us possibly identify size differential issues.
     # print(
-    #     "\nExpected size: {} | Inspected size: {} | Confidence margin percentage: {:.2%} | Confidence: {}".format(
+    #     "\nInspected size: {} | Expected size: {} | Confidence margin percentage: {:.2%} | Confidence: {}".format(
+    #         inspected
     #         expected,
-    #         inspected,
     #         percentage,
     #         int(-(expected - (inspected + (expected * percentage))))
     #     )


### PR DESCRIPTION
Download of small files fails with file size mismatch error.

The buffer of the download file was not flushed on download completion resulting in sporadic file size mismatch errors mostly on small file sizes.

Buffer is now flushed after the download.